### PR TITLE
mix: fix issues related to CONFIG.mk and export_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 NAME = gcpt
 
 WORK_DIR = $(CURDIR)
+EXPORT_DIR = $(WORK_DIR)/export_include
 
 ifdef O
 	BUILD_DIR = $(shell readlink -f $(O))/build
@@ -42,10 +43,13 @@ CFLAGS += -nostdlib -fno-common -ffreestanding
 
 LDFLAGS =
 
+ifneq ($(filter clean,$(MAKECMDGOALS)),)
+else
 ifeq ($(wildcard CONFIG.mk),)
-	$(error "CONFIG.mk not found. Please run ./configure first.")
+$(error "CONFIG.mk not found. Please run ./configure first.")
 endif
 include CONFIG.mk
+endif
 #CSANITIZE := undefined
 #
 #CFLAGS += $(addprefix -fsanitize=, $(CSANITIZE))
@@ -64,8 +68,8 @@ OBJS = $(addprefix $(OBJ_DIR)/, $(addsuffix .o, $(basename $(SRCS))))
 	@python resource/nanopb/generator/nanopb_generator.py --strip-path $<
 	@mv $(basename $<).pb.h include/
 	@mkdir -p export_include
-	@cp include/$(notdir $(basename $<)).pb.h export_include/
-	@cp include/cpt_default_values.h export_include/
+	@cp include/$(notdir $(basename $<)).pb.h $(EXPORT_DIR)/
+	@cp include/cpt_default_values.h $(EXPORT_DIR)/
 
 # Compilation patterns
 $(OBJ_DIR)/%.o: %.c
@@ -89,3 +93,5 @@ clean:
 	@echo + RM ./build ./src/checkpoint.pb.c ./include/checkpoint.pb.h
 	@-rm -rf $(shell find src/ -name "*.pb.[ch]")
 	@-rm -rf $(BUILD_DIR)
+	@-rm -rf $(EXPORT_DIR)
+	@-rm -rf CONFIG.mk

--- a/configure
+++ b/configure
@@ -7,6 +7,7 @@ DISPLAY_CPU_N=""
 STOP_CPU_N=""
 USING_QEMU_DUAL_CORE_SYSTEM=""
 USING_BARE_METAL_WORKLOAD=""
+USING_DEFAULT_CONFIG=""
 MODE="normal"
 
 # 解析命令行参数
@@ -58,6 +59,7 @@ done
 
 case "$MODE" in
   normal)
+    USING_DEFAULT_CONFIG="1"
     ;;
   dual_core)
     USING_QEMU_DUAL_CORE_SYSTEM="1"
@@ -93,6 +95,9 @@ esac
   fi
   if [ -n "$USING_BARE_METAL_WORKLOAD" ]; then
     echo "CFLAGS += -DUSING_BARE_METAL_WORKLOAD=$USING_BARE_METAL_WORKLOAD"
+  fi
+  if [ -n "$USING_DEFAULT_CONFIG" ]; then
+    echo "CFLAGS += -DUSING_DEFAULT_CONFIG=$USING_DEFAULT_CONFIG"
   fi
 } > CONFIG.mk
 


### PR DESCRIPTION
- Skip CONFIG.mk check when running `make clean`.
- Correctly clean `CONFIG.mk` and `export_include` during `make clean`.
- Use the defined `export_include` variable instead of hardcoding.
- Add `USING_DEFAULT_CONFIG` as the default compilation option in `configure`